### PR TITLE
remove placement object on scene closing to address issue that leads to abandoned objects

### DIFF
--- a/Editor/BlockyEditorWindow.cs
+++ b/Editor/BlockyEditorWindow.cs
@@ -70,10 +70,13 @@ namespace PeartreeGames.BlockyWorldEditor.Editor
 
         private void OnSceneClosing(Scene scene, bool removingScene)
         {
+            if (_placementObject != null) DestroyImmediate(_placementObject);
             if (_settings.editMode == BlockyEditMode.None) return;
+
             // In Painting/Selection mode while scene is closing, process the scenes beforehand
             var preprocessors = GetScenePreprocessors();
             foreach (var preprocessor in preprocessors) preprocessor.ProcessScene(this, scene);
+
             EditorSceneManager.MarkSceneDirty(scene);
             EditorSceneManager.SaveScene(scene);
         }
@@ -85,7 +88,6 @@ namespace PeartreeGames.BlockyWorldEditor.Editor
 
             if (mode == BlockyEditMode.None)
             {
-                if (_placementObject != null) DestroyImmediate(_placementObject);
                 for (var i = 0; i < openSceneCount; i++)
                 {
                     var scene = SceneManager.GetSceneAt(i);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31539452/200360518-b0987c99-bc74-4eaa-b81c-ac8ac136e350.png)

I kept having more and more abandoned placement objects when switching between scenes in paint mode.

This should no longer occure when deleting the placement object before scene save. Originally it was getting deleted also when editomode was swtiched to none but I have found that this might be redundant now.

The objects also get deleted when:
- Editor looses  focus (OnLostFocus), is deleting the object most of the time.
- Editor is getting closed (OnDestroy)